### PR TITLE
Fix image url expiration on long documents

### DIFF
--- a/src/DocSendDownloader.js
+++ b/src/DocSendDownloader.js
@@ -19,13 +19,7 @@ let userIsAuthenticated = () => {
 let getSlideImageUrls = async () => {
     for(let i=1; i<=numSlides; i++) {
         let url = metadataEndpoint + String(i);
-        await fetch(url)
-        .then((response) => {
-            return response.json();
-        })
-        .then((data) => {
-            slideImageUrls.push(data.imageUrl);
-        })
+        slideImageUrls.push(url);
     }
 }
 

--- a/src/GeneratePDF.js
+++ b/src/GeneratePDF.js
@@ -22,12 +22,18 @@ const getImageAsBlob = async (url) =>
 
 const addSlidesToPDF = async (imageUrls) =>{
     for (let i=0; i<imageUrls.length; i++) {
-        await getImageAsBlob(imageUrls[i]).then(data => {
+        await fetch(imageUrls[i])
+        .then((response) => {
+            return response.json();
+        })
+        .then((data) => {
+            return getImageAsBlob(data.imageUrl);
+        })
+        .then((data) => {
             const img = doc.openImage(data);
             doc.addPage({size: [img.width, img.height]});
             doc.image(img, 0, 0);
-        
-        })    
+        })
     }
 }
 


### PR DESCRIPTION
Generate the page url on-demand to avoid link expiration.

Fixes the issue https://github.com/mdesilva/DocSendDownloader/issues/6